### PR TITLE
Add JWT auth and login flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { login } from '@/lib/api'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [form, setForm] = useState({ username: '', password: '' })
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    try {
+      await login(form)
+      router.push('/stories')
+    } catch (err: any) {
+      setError('Failed to login')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <Input id="username" value={form.username} onChange={e => setForm({ ...form, username: e.target.value })} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input type="password" id="password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} required />
+        </div>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <Button type="submit" className="w-full">Login</Button>
+      </form>
+    </div>
+  )
+}
+

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -26,6 +26,11 @@ export default function HomePage() {
                 View Demo
               </Button>
             </Link>
+            <Link href="/login">
+              <Button size="lg" variant="outline">
+                Login
+              </Button>
+            </Link>
           </div>
         </div>
       </section>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,119 @@
+export interface Story {
+  id: string;
+  user_id: string;
+  title: string;
+  genre?: string;
+  description?: string;
+  created_at: string;
+  updated_at?: string;
+  story_metadata?: Record<string, any>;
+}
+
+export interface CreateStoryRequest {
+  title: string;
+  genre?: string;
+  description?: string;
+  story_metadata?: Record<string, any>;
+}
+
+export interface Chapter {
+  id: string;
+  story_id: string;
+  title: string;
+  content: string;
+  position: number;
+  word_count: number;
+  created_at: string;
+  updated_at?: string;
+}
+
+export interface CreateChapterRequest {
+  story_id: string;
+  title: string;
+  content: string;
+  position?: number;
+  branch_id?: string;
+}
+
+export interface GenerateChapterRequest {
+  story_id: string;
+  title: string;
+  prompt: string;
+  position?: number;
+  system_prompt?: string;
+}
+
+export const queryKeys = {
+  stories: ['stories'] as const,
+  story: (id: string) => ['stories', id] as const,
+  storyChapters: (id: string) => ['stories', id, 'chapters'] as const,
+  chapter: (id: string) => ['chapters', id] as const,
+};
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+let token: string | null = null;
+export function setToken(t: string | null) {
+  token = t;
+  if (typeof window !== 'undefined') {
+    if (t) localStorage.setItem('token', t);
+    else localStorage.removeItem('token');
+  }
+}
+
+if (typeof window !== 'undefined') {
+  const saved = localStorage.getItem('token');
+  if (saved) token = saved;
+}
+
+async function request(path: string, options: RequestInit = {}) {
+  const res = await fetch(`${API_URL}/api/v1${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function register(data: { username: string; password: string }) {
+  const res = await fetch(`${API_URL}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const json = await res.json();
+  setToken(json.access_token);
+  return json;
+}
+
+export async function login(data: { username: string; password: string }) {
+  const res = await fetch(`${API_URL}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const json = await res.json();
+  setToken(json.access_token);
+  return json;
+}
+
+export const api = {
+  getStories: () => request('/stories/'),
+  getStory: (id: string) => request(`/stories/${id}`),
+  createStory: (data: CreateStoryRequest) => request('/stories/', { method: 'POST', body: JSON.stringify(data) }),
+  updateStory: (id: string, data: Partial<CreateStoryRequest>) => request(`/stories/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteStory: (id: string) => request(`/stories/${id}`, { method: 'DELETE' }),
+  getStoryChapters: (storyId: string) => request(`/chapters/story/${storyId}`),
+  getChapter: (id: string) => request(`/chapters/${id}`),
+  createChapter: (data: CreateChapterRequest) => request('/chapters/', { method: 'POST', body: JSON.stringify(data) }),
+  updateChapter: (id: string, data: Partial<CreateChapterRequest>) => request(`/chapters/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteChapter: (id: string) => request(`/chapters/${id}`, { method: 'DELETE' }),
+  generateChapter: (data: GenerateChapterRequest) => request('/chapters/generate', { method: 'POST', body: JSON.stringify(data) }),
+  reorderChapters: (storyId: string, positions: Record<string, number>) => request(`/chapters/story/${storyId}/reorder`, { method: 'PUT', body: JSON.stringify(positions) }),
+};
+

--- a/services/auth/app/core.py
+++ b/services/auth/app/core.py
@@ -2,6 +2,10 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     SERVICE_NAME: str = "auth-service"
+    SECRET_KEY: str = "your-secret-key-change-this"
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+
     class Config:
         env_file = ".env"
         case_sensitive = True

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,7 +1,13 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+from jose import jwt, JWTError
+from passlib.context import CryptContext
+from typing import Dict
+
 from app.core import settings
+from app.schemas import UserCreate, Token
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -9,9 +15,58 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Quantum Writer Auth Service", version="2.0.0", docs_url="/api/docs", redoc_url="/api/redoc", lifespan=lifespan)
 
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+fake_users_db: Dict[str, str] = {}
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: Dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+def decode_token(token: str) -> str:
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return username
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+def get_current_user(authorization: str | None = None) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    token = authorization.split(" ", 1)[1]
+    return decode_token(token)
+
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
 
 @app.get("/health")
 async def health_check():
     return {"status": "healthy", "service": settings.SERVICE_NAME}
+
+
+@app.post("/register", response_model=Token)
+async def register(user: UserCreate):
+    if user.username in fake_users_db:
+        raise HTTPException(status_code=400, detail="User already exists")
+    fake_users_db[user.username] = get_password_hash(user.password)
+    token = create_access_token({"sub": user.username})
+    return {"access_token": token, "token_type": "bearer"}
+
+
+@app.post("/login", response_model=Token)
+async def login(user: UserCreate):
+    hashed = fake_users_db.get(user.username)
+    if not hashed or not verify_password(user.password, hashed):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token({"sub": user.username})
+    return {"access_token": token, "token_type": "bearer"}
 

--- a/services/auth/app/schemas.py
+++ b/services/auth/app/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -5,3 +5,5 @@ pydantic-settings==2.1.0
 httpx==0.26.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4

--- a/services/auth/tests/test_auth.py
+++ b/services/auth/tests/test_auth.py
@@ -1,0 +1,15 @@
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_register_and_login():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/register", json={"username": "alice", "password": "secret"})
+        assert resp.status_code == 200
+        token = resp.json()["access_token"]
+        assert token
+
+        resp = await ac.post("/login", json={"username": "alice", "password": "secret"})
+        assert resp.status_code == 200
+        assert resp.json()["access_token"]

--- a/services/story/app/api/v1/chapters.py
+++ b/services/story/app/api/v1/chapters.py
@@ -5,16 +5,18 @@ from typing import List
 from app.db.database import get_db
 from app.services.chapter_service import ChapterService
 from app.schemas.chapter import (
-    ChapterCreate, ChapterUpdate, ChapterResponse, 
+    ChapterCreate, ChapterUpdate, ChapterResponse,
     ChapterListResponse, GenerateChapterRequest
 )
+from app.core.security import get_current_user
 
 router = APIRouter()
 
 @router.post("/", response_model=ChapterResponse)
 async def create_chapter(
     chapter_data: ChapterCreate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Create a new chapter"""
     service = ChapterService(db)
@@ -24,7 +26,8 @@ async def create_chapter(
 @router.get("/{chapter_id}", response_model=ChapterResponse)
 async def get_chapter(
     chapter_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Get a chapter by ID"""
     service = ChapterService(db)
@@ -37,7 +40,8 @@ async def get_chapter(
 async def update_chapter(
     chapter_id: str,
     chapter_data: ChapterUpdate,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Update a chapter"""
     service = ChapterService(db)
@@ -49,7 +53,8 @@ async def update_chapter(
 @router.delete("/{chapter_id}")
 async def delete_chapter(
     chapter_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Delete a chapter"""
     service = ChapterService(db)
@@ -61,7 +66,8 @@ async def delete_chapter(
 @router.get("/story/{story_id}", response_model=List[ChapterListResponse])
 async def get_story_chapters(
     story_id: str,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Get all chapters for a story"""
     service = ChapterService(db)
@@ -72,7 +78,8 @@ async def get_story_chapters(
 async def generate_chapter(
     request: GenerateChapterRequest,
     model: str = Query("groq", description="AI model to use: claude, groq, gpt"),
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Generate a new chapter using AI"""
     service = ChapterService(db)
@@ -86,7 +93,8 @@ async def generate_chapter(
 async def reorder_chapters(
     story_id: str,
     chapter_positions: dict,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user)
 ):
     """Reorder chapters in a story"""
     service = ChapterService(db)

--- a/services/story/app/api/v1/stories.py
+++ b/services/story/app/api/v1/stories.py
@@ -1,21 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, Header
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-from typing import List, Optional
+from typing import List
 
 from app.db.database import get_db
 from app.models.story import Story
 from app.models.branch import Branch
 from app.schemas.story import StoryCreate, StoryUpdate, StoryResponse
+from app.core.security import get_current_user
 
 router = APIRouter()
 
 
-async def get_current_user(x_user_id: Optional[str] = Header(None)) -> str:
-    """Simple auth dependency expecting an X-User-Id header."""
-    if not x_user_id:
-        raise HTTPException(status_code=401, detail="Missing authentication")
-    return x_user_id
 
 @router.post("/", response_model=StoryResponse)
 async def create_story(

--- a/services/story/app/core/security.py
+++ b/services/story/app/core/security.py
@@ -1,0 +1,18 @@
+from fastapi import Header, HTTPException
+from jose import jwt, JWTError
+
+from .config import settings
+
+
+def get_current_user(authorization: str | None = Header(None)) -> str:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    token = authorization.split(" ", 1)[1]
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        username: str | None = payload.get("sub")
+        if not username:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return username
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid token")


### PR DESCRIPTION
## Summary
- implement JWT auth service with /register and /login routes
- secure story and chapter routes with token verification
- create frontend login page and API helpers
- expose new library dir via .gitignore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_684b33ecbd9883268e9584ce39fbc180