### PR TITLE
Add branch CRUD endpoints and tests

### DIFF
--- a/services/story/app/api/v1/branches.py
+++ b/services/story/app/api/v1/branches.py
@@ -1,12 +1,96 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from typing import List
+import uuid
 
 from app.db.database import get_db
+from app.models.branch import Branch
+from app.models.story import Story
+from app.schemas.branch import BranchCreate, BranchUpdate, BranchResponse
+from app.core.security import get_current_user
 
 router = APIRouter()
 
-@router.get("/")
-async def list_branches():
-    """List branches - to be implemented"""
-    return {"message": "Branches endpoint - to be implemented"}
+@router.post("/", response_model=BranchResponse)
+async def create_branch(
+    branch: BranchCreate,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Story).where(Story.id == branch.story_id, Story.user_id == user_id)
+    )
+    story = result.scalar_one_or_none()
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    db_branch = Branch(
+        id=str(uuid.uuid4()),
+        story_id=branch.story_id,
+        parent_branch_id=branch.parent_branch_id,
+        name=branch.name,
+        description=branch.description,
+        status=branch.status or "active",
+        branch_metadata=branch.branch_metadata or {},
+    )
+    db.add(db_branch)
+    await db.commit()
+    await db.refresh(db_branch)
+    return db_branch
+
+@router.get("/story/{story_id}", response_model=List[BranchResponse])
+async def list_branches(
+    story_id: str,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Story).where(Story.id == story_id, Story.user_id == user_id)
+    )
+    story = result.scalar_one_or_none()
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    result = await db.execute(select(Branch).where(Branch.story_id == story_id))
+    branches = result.scalars().all()
+    return list(branches)
+
+@router.put("/{branch_id}", response_model=BranchResponse)
+async def update_branch(
+    branch_id: str,
+    branch_update: BranchUpdate,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Branch)
+        .join(Story, Branch.story_id == Story.id)
+        .where(Branch.id == branch_id, Story.user_id == user_id)
+    )
+    branch = result.scalar_one_or_none()
+    if not branch:
+        raise HTTPException(status_code=404, detail="Branch not found")
+    for field, value in branch_update.model_dump(exclude_unset=True).items():
+        setattr(branch, field, value)
+    await db.commit()
+    await db.refresh(branch)
+    return branch
+
+@router.delete("/{branch_id}")
+async def delete_branch(
+    branch_id: str,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(Branch)
+        .join(Story, Branch.story_id == Story.id)
+        .where(Branch.id == branch_id, Story.user_id == user_id)
+    )
+    branch = result.scalar_one_or_none()
+    if not branch:
+        raise HTTPException(status_code=404, detail="Branch not found")
+    await db.delete(branch)
+    await db.commit()
+    return {"message": "Branch deleted successfully"}

--- a/services/story/app/schemas/branch.py
+++ b/services/story/app/schemas/branch.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, ConfigDict
+from typing import Optional, Dict, Any
+from datetime import datetime
+
+class BranchBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    parent_branch_id: Optional[str] = None
+    branch_metadata: Optional[Dict[str, Any]] = {}
+    status: Optional[str] = "active"
+
+class BranchCreate(BranchBase):
+    story_id: str
+
+class BranchUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    parent_branch_id: Optional[str] = None
+    branch_metadata: Optional[Dict[str, Any]] = None
+    status: Optional[str] = None
+
+class BranchResponse(BranchBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    story_id: str
+    is_main: bool = False
+    created_at: datetime
+    updated_at: Optional[datetime] = None

--- a/services/story/tests/test_branches.py
+++ b/services/story/tests/test_branches.py
@@ -1,0 +1,72 @@
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy import select
+
+from app.db import database as db
+from app.models.branch import Branch
+from app.main import app
+
+@pytest.fixture
+async def test_app(monkeypatch):
+    test_engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    TestSessionLocal = async_sessionmaker(test_engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def override_get_db():
+        async with TestSessionLocal() as session:
+            yield session
+
+    import app.main as app_main
+    monkeypatch.setattr(db, "engine", test_engine, raising=False)
+    monkeypatch.setattr(db, "AsyncSessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(app_main, "engine", test_engine, raising=False)
+    app_main.app.dependency_overrides[db.get_db] = override_get_db
+
+    from app.core import security
+    app_main.app.dependency_overrides[security.get_current_user] = lambda: "user1"
+
+    async with test_engine.begin() as conn:
+        await conn.run_sync(db.Base.metadata.create_all)
+
+    yield app_main.app, TestSessionLocal
+
+    app_main.app.dependency_overrides.clear()
+    await test_engine.dispose()
+
+@pytest.mark.asyncio
+async def test_branch_crud(test_app):
+    app, SessionLocal = test_app
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/api/v1/stories/",
+            json={"title": "My Story", "genre": "fantasy"},
+        )
+        assert resp.status_code == 200
+        story_id = resp.json()["id"]
+
+        resp = await ac.post(
+            "/api/v1/branches/",
+            json={"story_id": story_id, "name": "side", "description": "desc"},
+        )
+        assert resp.status_code == 200
+        branch_id = resp.json()["id"]
+
+        resp = await ac.get(f"/api/v1/branches/story/{story_id}")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+
+        resp = await ac.put(
+            f"/api/v1/branches/{branch_id}",
+            json={"name": "updated"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "updated"
+
+        resp = await ac.delete(f"/api/v1/branches/{branch_id}")
+        assert resp.status_code == 200
+
+    async with SessionLocal() as session:
+        result = await session.execute(select(Branch).where(Branch.story_id == story_id))
+        branches = result.scalars().all()
+        assert len(branches) == 1
+        assert branches[0].is_main


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for branches
- add branch schema definitions
- add unit tests covering branch operations

## Testing
- `pytest services/story/tests/test_branches.py::test_branch_crud -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_684e10cb5c508326b09d8194e08d04d5