### PR TITLE
Add login/register flow and auth guards

### DIFF
--- a/frontend/src/app/login/register/page.tsx
+++ b/frontend/src/app/login/register/page.tsx
@@ -6,9 +6,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import Link from 'next/link'
-import { login } from '@/lib/api'
+import { register } from '@/lib/api'
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const router = useRouter()
   const [form, setForm] = useState({ username: '', password: '' })
   const [error, setError] = useState('')
@@ -17,10 +17,10 @@ export default function LoginPage() {
     e.preventDefault()
     setError('')
     try {
-      await login(form)
+      await register(form)
       router.push('/stories')
     } catch (err: any) {
-      setError('Failed to login')
+      setError('Failed to register')
     }
   }
 
@@ -29,22 +29,32 @@ export default function LoginPage() {
       <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
         <div className="space-y-2">
           <Label htmlFor="username">Username</Label>
-          <Input id="username" value={form.username} onChange={e => setForm({ ...form, username: e.target.value })} required />
+          <Input
+            id="username"
+            value={form.username}
+            onChange={(e) => setForm({ ...form, username: e.target.value })}
+            required
+          />
         </div>
         <div className="space-y-2">
           <Label htmlFor="password">Password</Label>
-          <Input type="password" id="password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} required />
+          <Input
+            type="password"
+            id="password"
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+            required
+          />
         </div>
         {error && <p className="text-red-500 text-sm">{error}</p>}
-        <Button type="submit" className="w-full">Login</Button>
+        <Button type="submit" className="w-full">Register</Button>
         <p className="text-center text-sm text-muted-foreground">
-          Don't have an account?{' '}
-          <Link href="/login/register" className="underline">
-            Register
+          Already have an account?{' '}
+          <Link href="/login" className="underline">
+            Login
           </Link>
         </p>
       </form>
     </div>
   )
 }
-

--- a/frontend/src/app/stories/[id]/page.tsx
+++ b/frontend/src/app/stories/[id]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { getToken } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
@@ -32,6 +33,12 @@ export default function StoryPage({ params }: StoryPageProps) {
   const { data: story, isLoading: storyLoading, error: storyError } = useStory(params.id);
   const { data: chapters, isLoading: chaptersLoading } = useStoryChapters(params.id);
   const generateChapterMutation = useGenerateChapter();
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push('/login');
+    }
+  }, [router]);
 
   const handleGenerateChapter = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/app/stories/page.tsx
+++ b/frontend/src/app/stories/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getToken } from '@/lib/api';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
@@ -27,6 +29,7 @@ const GENRES = [
 ];
 
 export default function StoriesPage() {
+  const router = useRouter();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [newStory, setNewStory] = useState({
     title: '',
@@ -36,6 +39,12 @@ export default function StoriesPage() {
 
   const { data: stories, isLoading, error } = useStories();
   const createStoryMutation = useCreateStory();
+
+  useEffect(() => {
+    if (!getToken()) {
+      router.push('/login');
+    }
+  }, [router]);
 
   const handleCreateStory = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -60,6 +60,14 @@ export function setToken(t: string | null) {
   }
 }
 
+export function getToken() {
+  return token;
+}
+
+export function isLoggedIn() {
+  return !!token;
+}
+
 if (typeof window !== 'undefined') {
   const saved = localStorage.getItem('token');
   if (saved) token = saved;


### PR DESCRIPTION
## Summary
- create `/login/register` page and link from login
- store auth token helpers in `api.ts`
- redirect unauthenticated users from `/stories` and `/stories/[id]`

## Testing
- `npm test --silent` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_b_684e10db9fbc83269f880034cf28ddf1