### PR TITLE
Add analysis engine and integrate analysis endpoints

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -41,7 +41,7 @@ Quantum Writer has progressed from a bare skeleton to a usable MVP. The project 
    - UI for exploring alternative narratives
 
 3. **Analysis Service**
-   - NLP and plot analysis features still empty
+   - Basic character extraction and plot analysis implemented
 
 4. **Authentication & Collaboration**
    - JWT auth only partially implemented

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A modern, scalable platform for creating AI-assisted interactive narratives with
 - ✅ **Database Persistence**: PostgreSQL with complete story/chapter schema
 - ✅ **API Gateway**: Kong routing with microservices architecture
 - ✅ **Context Continuity**: AI maintains narrative consistency using previous chapters
+- ✅ **Story Analysis**: Basic character extraction and plot summarization
 - ✅ **Docker Environment**: Full containerized development setup
 
 ### 🎯 Key MVP Achievements
@@ -41,7 +42,7 @@ A modern, scalable platform for creating AI-assisted interactive narratives with
 | API Gateway | 8000 | ✅ **Working** | Kong routing |
 | Story Service | 8010 | ✅ **Working** | Story/chapter CRUD with AI |
 | AI Service | 8011 | ✅ **Working** | Multi-model LLM integration |
-| Analysis Service | 8012 | ✅ Skeleton | NLP analysis |
+| Analysis Service | 8012 | ✅ Basic | Character & plot analysis |
 | Context Service | 8013 | ✅ Skeleton | Vector search |
 | Auth Service | 8014 | ✅ Skeleton | Authentication |
 | WebSocket Service | 8015 | ✅ Skeleton | Real-time sync |

--- a/services/ai/tests/test_generate.py
+++ b/services/ai/tests/test_generate.py
@@ -12,6 +12,7 @@ async def ai_app(monkeypatch):
     from app.services.groq_service import groq_service
     from app.services.openai_service import openai_service
     from app.services.anthropic_service import anthropic_service
+    from app.api.v1 import generate as generate_module
 
     async def fake_generate_content(*args, **kwargs):
         return "Generated"
@@ -22,6 +23,11 @@ async def ai_app(monkeypatch):
     for service in (groq_service, openai_service, anthropic_service):
         monkeypatch.setattr(service, "generate_content", fake_generate_content)
         monkeypatch.setattr(service, "estimate_tokens", fake_estimate_tokens)
+
+    async def fake_run_analysis(text: str):
+        return None
+
+    monkeypatch.setattr(generate_module, "_run_analysis", fake_run_analysis)
 
     yield app
 

--- a/services/analysis/app/services/analysis_engine.py
+++ b/services/analysis/app/services/analysis_engine.py
@@ -1,0 +1,28 @@
+import re
+from typing import List, Dict
+
+class AnalysisEngine:
+    """Simple NLP routines for story analysis."""
+
+    @staticmethod
+    def extract_characters(text: str) -> List[str]:
+        """Return a list of unique capitalized names found in the text."""
+        words = re.findall(r"\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*", text)
+        seen = set()
+        characters: List[str] = []
+        for w in words:
+            if w not in seen:
+                seen.add(w)
+                characters.append(w)
+        return characters
+
+    @staticmethod
+    def analyze_plot(text: str) -> Dict[str, object]:
+        """Return a naive plot summary using the first and last sentences."""
+        sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+        if not sentences:
+            return {"summary": ""}
+        summary = sentences[0]
+        if len(sentences) > 1:
+            summary += " ... " + sentences[-1]
+        return {"summary": summary, "sentence_count": len(sentences)}

--- a/services/analysis/tests/test_analysis.py
+++ b/services/analysis/tests/test_analysis.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_character_extraction():
+    text = "Alice and Bob met Charlie. Alice greeted Bob."
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/api/v1/analyze/characters", json={"text": text})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(["Alice", "Bob", "Charlie"]).issubset(set(data["characters"]))
+
+@pytest.mark.asyncio
+async def test_plot_analysis():
+    text = "Alice went to town. Bob followed. They found treasure."
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/api/v1/analyze/plot", json={"text": text})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "summary" in data and data["summary"]
+    assert data["sentence_count"] == 3


### PR DESCRIPTION
## Summary
- implement a simple `AnalysisEngine` for character extraction and plot summaries
- expose `/api/v1/analyze/characters` and `/api/v1/analyze/plot` routes
- call analysis service from AI generation endpoints
- patch AI tests to stub analysis calls and add new analysis tests
- document new capabilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_684e1528ad648326ba05fa60e06722cb