### PR TITLE
Implement auth refresh tokens and collaborative editing

### DIFF
--- a/frontend/src/app/stories/[id]/edit/page.tsx
+++ b/frontend/src/app/stories/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useStory, useStoryChapters, useUpdateChapter } from '@/hooks/useStories'
@@ -8,6 +8,11 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { ArrowLeft, Save } from 'lucide-react'
+import * as Y from 'yjs'
+import { WebsocketProvider } from 'y-websocket'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
 
 interface EditPageProps {
   params: { id: string }
@@ -19,6 +24,57 @@ export default function EditPage({ params }: EditPageProps) {
   const { data: chapters, isLoading: chaptersLoading } = useStoryChapters(params.id)
   const updateChapter = useUpdateChapter()
   const [edited, setEdited] = useState<Record<string, string>>({})
+
+  const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:8000'
+
+  function useCollab(chapterId: string) {
+    const ydocRef = useRef<Y.Doc>()
+    const providerRef = useRef<WebsocketProvider>()
+
+    const editor = useEditor({
+      extensions: [
+        StarterKit,
+        Collaboration.configure({ document: (ydocRef.current = new Y.Doc()) })
+      ],
+    })
+
+    useEffect(() => {
+      const provider = new WebsocketProvider(`${WS_URL}/ws/${chapterId}`, ydocRef.current!)
+      providerRef.current = provider
+      return () => {
+        provider.destroy()
+        ydocRef.current?.destroy()
+      }
+    }, [chapterId])
+
+    return editor
+  }
+
+  function ChapterEditor({ chapter }: { chapter: any }) {
+    const editor = useCollab(chapter.id)
+    return (
+      <Card key={chapter.id}>
+        <CardHeader>
+          <CardTitle>{chapter.title}</CardTitle>
+          <CardDescription>Chapter {chapter.position}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {editor ? (
+            <EditorContent editor={editor} className="border rounded p-2" />
+          ) : (
+            <Textarea
+              value={edited[chapter.id] ?? chapter.content}
+              onChange={(e) => setEdited({ ...edited, [chapter.id]: e.target.value })}
+              rows={10}
+            />
+          )}
+          <Button onClick={() => handleSave(chapter.id)} disabled={updateChapter.isPending}>
+            <Save className="h-4 w-4 mr-2" /> Save
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
 
   const handleSave = async (chapterId: string) => {
     const content = edited[chapterId]
@@ -62,25 +118,7 @@ export default function EditPage({ params }: EditPageProps) {
       ) : chapters && chapters.length > 0 ? (
         <div className="space-y-6">
           {chapters.sort((a, b) => a.position - b.position).map(chapter => (
-            <Card key={chapter.id}>
-              <CardHeader>
-                <CardTitle>{chapter.title}</CardTitle>
-                <CardDescription>Chapter {chapter.position}</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <Textarea
-                  value={edited[chapter.id] ?? chapter.content}
-                  onChange={e => setEdited({ ...edited, [chapter.id]: e.target.value })}
-                  rows={10}
-                />
-                <Button
-                  onClick={() => handleSave(chapter.id)}
-                  disabled={updateChapter.isPending}
-                >
-                  <Save className="h-4 w-4 mr-2" /> Save
-                </Button>
-              </CardContent>
-            </Card>
+            <ChapterEditor key={chapter.id} chapter={chapter} />
           ))}
         </div>
       ) : (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,7 @@ export const queryKeys = {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 let token: string | null = null;
+let refreshToken: string | null = null;
 export function setToken(t: string | null) {
   token = t;
   if (typeof window !== 'undefined') {
@@ -60,8 +61,20 @@ export function setToken(t: string | null) {
   }
 }
 
+export function setRefreshToken(t: string | null) {
+  refreshToken = t;
+  if (typeof window !== 'undefined') {
+    if (t) localStorage.setItem('refreshToken', t);
+    else localStorage.removeItem('refreshToken');
+  }
+}
+
 export function getToken() {
   return token;
+}
+
+export function getRefreshToken() {
+  return refreshToken;
 }
 
 export function isLoggedIn() {
@@ -71,17 +84,31 @@ export function isLoggedIn() {
 if (typeof window !== 'undefined') {
   const saved = localStorage.getItem('token');
   if (saved) token = saved;
+  const savedRefresh = localStorage.getItem('refreshToken');
+  if (savedRefresh) refreshToken = savedRefresh;
 }
 
 async function request(path: string, options: RequestInit = {}) {
-  const res = await fetch(`${API_URL}/api/v1${path}`, {
-    ...options,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(options.headers || {}),
-    },
-  });
+  const doRequest = async () =>
+    fetch(`${API_URL}/api/v1${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(options.headers || {}),
+      },
+    });
+
+  let res = await doRequest();
+  if (res.status === 401 && refreshToken) {
+    try {
+      await refreshAccessToken();
+      res = await doRequest();
+    } catch {
+      logout();
+      throw new Error('Unauthorized');
+    }
+  }
   if (!res.ok) throw new Error(await res.text());
   return res.json();
 }
@@ -95,6 +122,7 @@ export async function register(data: { username: string; password: string }) {
   if (!res.ok) throw new Error(await res.text());
   const json = await res.json();
   setToken(json.access_token);
+  setRefreshToken(json.refresh_token);
   return json;
 }
 
@@ -107,7 +135,25 @@ export async function login(data: { username: string; password: string }) {
   if (!res.ok) throw new Error(await res.text());
   const json = await res.json();
   setToken(json.access_token);
+  setRefreshToken(json.refresh_token);
   return json;
+}
+
+export async function refreshAccessToken() {
+  if (!refreshToken) throw new Error('No refresh token');
+  const res = await fetch(`${API_URL}/refresh?refresh=${encodeURIComponent(refreshToken)}`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error(await res.text());
+  const data = await res.json();
+  setToken(data.access_token);
+  setRefreshToken(data.refresh_token);
+  return data;
+}
+
+export function logout() {
+  setToken(null);
+  setRefreshToken(null);
 }
 
 export const api = {

--- a/services/auth/app/core.py
+++ b/services/auth/app/core.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "your-secret-key-change-this"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    DATABASE_URL: str = "postgresql://postgres:postgres@localhost:5432/quantum_writer"
 
     class Config:
         env_file = ".env"

--- a/services/auth/app/db/database.py
+++ b/services/auth/app/db/database.py
@@ -1,0 +1,22 @@
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import declarative_base
+
+from app.core import settings
+
+engine = create_async_engine(
+    settings.DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://"),
+    echo=True,
+    future=True,
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+Base = declarative_base()
+
+async def get_db():
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/services/auth/app/main.py
+++ b/services/auth/app/main.py
@@ -1,22 +1,27 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from jose import jwt, JWTError
 from passlib.context import CryptContext
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
 from typing import Dict
 
 from app.core import settings
 from app.schemas import UserCreate, Token
+from app.db.database import Base, engine, get_db
+from app.models.user import User
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
     yield
 
 app = FastAPI(title="Quantum Writer Auth Service", version="2.0.0", docs_url="/api/docs", redoc_url="/api/redoc", lifespan=lifespan)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-fake_users_db: Dict[str, str] = {}
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
@@ -30,6 +35,12 @@ def create_access_token(data: Dict, expires_delta: timedelta | None = None) -> s
     to_encode.update({"exp": expire})
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
+def create_refresh_token(data: Dict, expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(days=7))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
 def decode_token(token: str) -> str:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
@@ -40,11 +51,16 @@ def decode_token(token: str) -> str:
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid token")
 
-def get_current_user(authorization: str | None = None) -> str:
+async def get_current_user(authorization: str | None = None, db: AsyncSession = Depends(get_db)) -> str:
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Not authenticated")
     token = authorization.split(" ", 1)[1]
-    return decode_token(token)
+    username = decode_token(token)
+    result = await db.execute(select(User).where(User.username == username))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return username
 
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
 
@@ -54,19 +70,46 @@ async def health_check():
 
 
 @app.post("/register", response_model=Token)
-async def register(user: UserCreate):
-    if user.username in fake_users_db:
+async def register(user: UserCreate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.username == user.username))
+    if result.scalar_one_or_none():
         raise HTTPException(status_code=400, detail="User already exists")
-    fake_users_db[user.username] = get_password_hash(user.password)
+
+    refresh = create_refresh_token({"sub": user.username})
+    db_user = User(
+        username=user.username,
+        hashed_password=get_password_hash(user.password),
+        refresh_token=refresh,
+    )
+    db.add(db_user)
+    await db.commit()
     token = create_access_token({"sub": user.username})
-    return {"access_token": token, "token_type": "bearer"}
+    return {"access_token": token, "refresh_token": refresh, "token_type": "bearer"}
+
+
+@app.post("/refresh", response_model=Token)
+async def refresh_token_endpoint(refresh: str, db: AsyncSession = Depends(get_db)):
+    username = decode_token(refresh)
+    result = await db.execute(select(User).where(User.username == username, User.refresh_token == refresh))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+    new_refresh = create_refresh_token({"sub": username})
+    user.refresh_token = new_refresh
+    await db.commit()
+    access = create_access_token({"sub": username})
+    return {"access_token": access, "refresh_token": new_refresh, "token_type": "bearer"}
 
 
 @app.post("/login", response_model=Token)
-async def login(user: UserCreate):
-    hashed = fake_users_db.get(user.username)
-    if not hashed or not verify_password(user.password, hashed):
+async def login(user: UserCreate, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(User).where(User.username == user.username))
+    db_user = result.scalar_one_or_none()
+    if not db_user or not verify_password(user.password, db_user.hashed_password):
         raise HTTPException(status_code=401, detail="Invalid credentials")
+    refresh = create_refresh_token({"sub": user.username})
+    db_user.refresh_token = refresh
+    await db.commit()
     token = create_access_token({"sub": user.username})
-    return {"access_token": token, "token_type": "bearer"}
+    return {"access_token": token, "refresh_token": refresh, "token_type": "bearer"}
 

--- a/services/auth/app/models/user.py
+++ b/services/auth/app/models/user.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, String
+from app.db.database import Base
+import uuid
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    username = Column(String(100), unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    refresh_token = Column(String, nullable=True)

--- a/services/auth/app/schemas.py
+++ b/services/auth/app/schemas.py
@@ -6,4 +6,5 @@ class UserCreate(BaseModel):
 
 class Token(BaseModel):
     access_token: str
+    refresh_token: str | None = None
     token_type: str = "bearer"

--- a/services/auth/requirements.txt
+++ b/services/auth/requirements.txt
@@ -7,3 +7,5 @@ pytest==7.4.4
 pytest-asyncio==0.23.3
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
+sqlalchemy==2.0.25
+asyncpg==0.29.0

--- a/services/auth/tests/test_auth.py
+++ b/services/auth/tests/test_auth.py
@@ -7,9 +7,17 @@ async def test_register_and_login():
     async with AsyncClient(app=app, base_url="http://test") as ac:
         resp = await ac.post("/register", json={"username": "alice", "password": "secret"})
         assert resp.status_code == 200
-        token = resp.json()["access_token"]
-        assert token
+        data = resp.json()
+        token = data["access_token"]
+        refresh = data["refresh_token"]
+        assert token and refresh
 
         resp = await ac.post("/login", json={"username": "alice", "password": "secret"})
         assert resp.status_code == 200
-        assert resp.json()["access_token"]
+        login_data = resp.json()
+        assert login_data["access_token"] and login_data["refresh_token"]
+
+        resp = await ac.post("/refresh", params={"refresh": login_data["refresh_token"]})
+        assert resp.status_code == 200
+        refreshed = resp.json()
+        assert refreshed["access_token"] and refreshed["refresh_token"]

--- a/services/story/app/models/__init__.py
+++ b/services/story/app/models/__init__.py
@@ -2,5 +2,6 @@ from app.models.story import Story
 from app.models.chapter import Chapter
 from app.models.branch import Branch
 from app.models.character import Character
+from app.models.user import User
 
-__all__ = ["Story", "Chapter", "Branch", "Character"]
+__all__ = ["Story", "Chapter", "Branch", "Character", "User"]

--- a/services/story/app/models/story.py
+++ b/services/story/app/models/story.py
@@ -13,8 +13,8 @@ class Story(Base):
     description = Column(Text)
     story_metadata = Column(JSON, default={})
     
-    # User relationship (will be added with auth service)
-    user_id = Column(String, nullable=False)
+    # User relationship
+    user_id = Column(String, ForeignKey("users.id"), nullable=False)
     
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/services/story/app/models/user.py
+++ b/services/story/app/models/user.py
@@ -1,0 +1,7 @@
+from sqlalchemy import Column, String
+from app.db.database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True)

--- a/services/story/tests/test_branches.py
+++ b/services/story/tests/test_branches.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 from app.db import database as db
 from app.models.branch import Branch
+from app.models.user import User
 from app.main import app
 
 @pytest.fixture
@@ -27,6 +28,7 @@ async def test_app(monkeypatch):
 
     async with test_engine.begin() as conn:
         await conn.run_sync(db.Base.metadata.create_all)
+        await conn.execute(User.__table__.insert().values(id="user1"))
 
     yield app_main.app, TestSessionLocal
 

--- a/services/story/tests/test_story_chapters.py
+++ b/services/story/tests/test_story_chapters.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from app.db import database as db
 from app.models.branch import Branch
 from app.models.chapter import Chapter
+from app.models.user import User
 from app.main import app
 
 @pytest.fixture
@@ -26,6 +27,7 @@ async def test_app(monkeypatch):
 
     async with test_engine.begin() as conn:
         await conn.run_sync(db.Base.metadata.create_all)
+        await conn.execute(User.__table__.insert().values(id="user1"))
 
     yield app_main.app, TestSessionLocal
 

--- a/services/websocket/app/main.py
+++ b/services/websocket/app/main.py
@@ -2,6 +2,12 @@ from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 from app.core import settings
+from ypy_websocket import WebsocketServer
+from ypy_websocket.ystore import MemoryYStore
+
+ystore = MemoryYStore()
+ws_server = WebsocketServer(ystore=ystore)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -15,9 +21,7 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, 
 async def health_check():
     return {"status": "healthy", "service": settings.SERVICE_NAME}
 
-@app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
-    await websocket.accept()
-    await websocket.send_text("connected")
-    await websocket.close()
+@app.websocket("/ws/{room_id}")
+async def websocket_endpoint(websocket: WebSocket, room_id: str):
+    await ws_server.serve(websocket, room_id)
 

--- a/services/websocket/requirements.txt
+++ b/services/websocket/requirements.txt
@@ -5,3 +5,5 @@ pydantic-settings==2.1.0
 httpx==0.26.0
 pytest==7.4.4
 pytest-asyncio==0.23.3
+y-py==0.6.0
+ypy-websocket==0.8.2


### PR DESCRIPTION
## Summary
- add database-backed auth with refresh tokens
- reference users table from stories
- refresh tokens and logout in `api.ts`
- integrate yjs websocket rooms
- collaborative editor for story chapters

## Testing
- `pytest services/auth/tests/test_auth.py::test_register_and_login -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest services/story/tests/test_story_chapters.py::test_create_story -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e152a690c8326a67ef3c4fc89794f